### PR TITLE
Making the static html page optional by cmd flag (-s, --show)

### DIFF
--- a/src/vis.py
+++ b/src/vis.py
@@ -315,13 +315,21 @@ def get_args():
         type=str,
         help="generate dotfile of graph",
     )
+    parser.add_argument(
+        "-s",
+        "--show",
+        default=False,
+        dest="show_graph",
+        action="store_true",
+        help="visualize graph in browser (static html page)",
+    )
     # TODO implement ability to ignore certain modules
     # parser.add_argument('-i', '--ignore', dest='ignorefile', type=str,
     # help='file that contains names of modules to ignore')
     return parser.parse_args()
 
 
-def generate_pyvis_visualization(mod_dict, dotfile=''):
+def generate_pyvis_visualization(mod_dict, dotfile='', show=False):
     def get_hex_color_of_shade(value):
         if value < 0 or value > 1:
             raise ValueError("Input value must be between 0 and 1")
@@ -392,11 +400,12 @@ def generate_pyvis_visualization(mod_dict, dotfile=''):
         nx.draw(nx_graph)
         write_dot(nx_graph, dotfile)
 
-    net = Network(directed=True)
-    net.from_nx(nx_graph)
-    net.show_buttons()
-    net.toggle_physics(True)
-    net.show('mygraph.html', notebook=False)
+    if show:
+        net = Network(directed=True)
+        net.from_nx(nx_graph)
+        net.show_buttons()
+        net.toggle_physics(True)
+        net.show('mygraph.html', notebook=False)
 
 def main():
 
@@ -412,7 +421,6 @@ def main():
         mod_dict = get_modules_in_dir(root_dir)
     
         
-
     add_immediate_deps_to_modules(mod_dict)
     print("Module dependencies:")
     for name, module in sorted(mod_dict.items()):
@@ -428,9 +436,9 @@ def main():
 
     # Creates the pyvis visualization
     if args.dotfile is not None:
-        generate_pyvis_visualization(mod_dict, dotfile=args.dotfile)
+        generate_pyvis_visualization(mod_dict, dotfile=args.dotfile, show=args.show_graph)
     else:
-        generate_pyvis_visualization(mod_dict)
+        generate_pyvis_visualization(mod_dict, show=args.show_graph)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Problem: The static html page is shown every time, even if there's only need for the listing on the terminal or the dotfile

Solution: Adding a command line flag to optionally toggle the html graph

Alternative: If desired, one could also make the graph show by default and add a cmd flag to not show the graph instead in order to keep original behavior. I decided for the proposed way because I think it's more practical but of course I'm open for your opinion, in the end it's your project.